### PR TITLE
Add gunicorn

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 peewee = "*"
+gunicorn = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "66a0b36df595fa056d68c95e28a65f63aed847326880992df39e3da5e2d37ca3"
+            "sha256": "d99933a7568f9213d7af8775f60d43a6f6587d2a0c4a9d19ff8f5d0cf305975c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.2"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e",
+                "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"
+            ],
+            "index": "pypi",
+            "version": "==20.1.0"
         },
         "importlib-metadata": {
             "hashes": [
@@ -137,6 +145,14 @@
             ],
             "index": "pypi",
             "version": "==3.14.8"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
+                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==60.5.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ $ export FLASK_APP=pdc
 $ pipenv run flask run
 ```
 
-
 ## Running on Production
 
 This project has a WSGI entry point if you want to use something like [gunicorn](https://flask.palletsprojects.com/en/2.0.x/deploying/wsgi-standalone/#gunicorn).
 
+Gunicorn has been added as a project dependency, and so you can run a production copy by typing:
+
+```
+$ pipenv run gunicorn --reload --bind 127.0.0.1:9090 wsgi:app
+```
+
+This could be set up using the process manager of your chice (e.g. [supervisord](http://supervisord.org/))


### PR DESCRIPTION
This PR adds gunicorn as a project dependency

The user COULD run the application without it, but by bundling it we make production deployment more straightforward because it's built into the pipenv.

Issue #52